### PR TITLE
Update dependencies to smbus2 and fix incorrect git clone URL in README

### DIFF
--- a/python/raspberryPi/DFRobot_GP8403.py
+++ b/python/raspberryPi/DFRobot_GP8403.py
@@ -11,7 +11,7 @@
 '''
 from __future__ import print_function
 import sys
-import smbus
+import smbus2 as smbus
 import time
 import datetime
 import RPi.GPIO as GPIO

--- a/python/raspberryPi/README.md
+++ b/python/raspberryPi/README.md
@@ -27,8 +27,8 @@ The Arduino library is provided for the I2C 0-5V/0-10V DAC module to set and sav
 
 ### 1. Create and activate a virtual environment
 ```bash
-python3 -m venv myenv
-source myenv/bin/activate
+python3 -m venv venv
+source venv/bin/activate
 ```
 
 ### 2. Install required dependencies

--- a/python/raspberryPi/README.md
+++ b/python/raspberryPi/README.md
@@ -24,18 +24,37 @@ The Arduino library is provided for the I2C 0-5V/0-10V DAC module to set and sav
 3. Save the voltage config(Will not be lost when powered down).
 
 ## Installation
-1. To use this library, first download the library file<br>
-```python
-sudo git clone https://github.com/DFRobot/DFRobot_GP8302
-```
-2. Open and run the routine. To execute a routine demo_x.py, enter python demo_x.py in the command line. For example, to execute the demo_set_current.py routine, you need to enter :<br>
 
-```python
+### 1. Create and activate a virtual environment
+```bash
+python3 -m venv myenv
+source myenv/bin/activate
+```
+
+### 2. Install required dependencies
+```bash
+pip install smbus2 rpi-gpio
+```
+
+### 3. Download the library
+To use this library, download the library file:
+```bash
+sudo git clone https://github.com/DFRobot/DFRobot_GP8403
+```
+
+### 4. Running the examples
+Open and run the routine. To execute a routine demo_x.py, enter python demo_x.py in the command line. For example, to execute the demo_set_current.py routine, you need to enter:
+```bash
 python demo_set_current.py 
-or
+# or
 python2 demo_set_current.py 
-or 
+# or 
 python3 demo_set_current.py
+```
+
+### 5. Deactivate virtual environment when done
+```bash
+deactivate
 ```
 
 ## Methods
@@ -115,6 +134,7 @@ python3 demo_set_current.py
 ## History
 
 - 2022/03/10 - Version 1.0.0 released.
+- 2025/05/23 - Version 1.0.1 updated for smbus2.
 
 ## Credits
 


### PR DESCRIPTION
## Summary

This PR addresses documentation errors and updates dependencies to improve installation reliability.

## Issues Addressed

1. **Incorrect repository URL** - Installation instructions referenced `DFRobot_GP8302` instead of `DFRobot_GP8403`
2. **Outdated dependency** - Code used unmaintained `smbus` library instead of current `smbus2`
3. **Missing environment setup** - No virtual environment instructions provided

## Changes

- Corrected git clone URL in installation documentation
- Updated import statement to use `smbus2` instead of `smbus`
- Added virtual environment setup instructions

## Rationale

`smbus2` is the actively maintained successor to `smbus`, providing improved Python 3 compatibility while maintaining API compatibility. Virtual environment setup prevents dependency conflicts and follows Python best practices.

## Migration

Users should install `smbus2` instead of `smbus`. Updated import to smbus as smbus

## Testing

Verified functionality on Raspberry Pi 4 and 5 with provided examples.